### PR TITLE
Assign Netclasses for USB and RF

### DIFF
--- a/connectors.kicad_sch
+++ b/connectors.kicad_sch
@@ -3310,6 +3310,128 @@
 		)
 		(uuid "fc46e304-57ad-4354-9996-282be68c3e7b")
 	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 74.93 142.24 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "13088e9e-ca5b-4d6a-823b-e198190039d1")
+		(property "Netclass" "USB"
+			(at 75.6285 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 26.67 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 93.98 165.1 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "2b858ee5-3f67-46c3-a407-33914a64b965")
+		(property "Netclass" "USB"
+			(at 95.25 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 45.72 19.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 74.93 165.1 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "389847cc-3096-4e8f-a260-a0e3f36c8fc3")
+		(property "Netclass" "USB"
+			(at 69.85 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 26.67 19.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 93.98 142.24 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "513db099-d473-4954-a9c4-733b9593894e")
+		(property "Netclass" "USB"
+			(at 94.6785 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 45.72 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
 	(symbol
 		(lib_id "Device:R_Small")
 		(at 59.69 140.97 270)

--- a/linht-hw.kicad_pro
+++ b/linht-hw.kicad_pro
@@ -138,9 +138,9 @@
         "min_through_hole_diameter": 0.3,
         "min_track_width": 0.15,
         "min_via_annular_width": 0.15,
-        "min_via_diameter": 0.5,
+        "min_via_diameter": 0.3,
         "solder_mask_to_copper_clearance": 0.0,
-        "use_height_for_length_calcs": true
+        "use_height_for_length_calcs": false
       },
       "teardrop_options": [
         {
@@ -485,13 +485,72 @@
         "via_diameter": 0.6,
         "via_drill": 0.3,
         "wire_width": 6
+      },
+      {
+        "clearance": 0.1,
+        "name": "RF",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 0,
+        "schematic_color": "rgb(132, 0, 132)",
+        "track_width": 0.234,
+        "via_diameter": 0.6,
+        "via_drill": 0.3
+      },
+      {
+        "clearance": 0.2,
+        "diff_pair_gap": 0.1,
+        "diff_pair_width": 0.165,
+        "name": "USB",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 1,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.165,
+        "via_diameter": 0.6,
+        "via_drill": 0.3
       }
     ],
     "meta": {
       "version": 4
     },
     "net_colors": null,
-    "netclass_assignments": null,
+    "netclass_assignments": {
+      "/Connectors/USB_DN": [
+        "USB"
+      ],
+      "/Connectors/USB_DP": [
+        "USB"
+      ],
+      "/Connectors/xUDN": [
+        "USB"
+      ],
+      "/Connectors/xUDP": [
+        "USB"
+      ],
+      "/RF/RF_IN": [
+        "RF"
+      ],
+      "/RF/RF_OUT": [
+        "RF"
+      ],
+      "Net-(FL1-IN)": [
+        "RF"
+      ],
+      "Net-(FL1-OUT)": [
+        "RF"
+      ],
+      "Net-(IC1-RFI)": [
+        "RF"
+      ],
+      "Net-(IC1-RFO_P)": [
+        "RF"
+      ],
+      "Net-(U2-RF_IN)": [
+        "RF"
+      ],
+      "Net-(U2-RF_OUT_2)": [
+        "RF"
+      ]
+    },
     "netclass_patterns": []
   },
   "pcbnew": {

--- a/rf.kicad_sch
+++ b/rf.kicad_sch
@@ -3461,6 +3461,246 @@
 		)
 		(uuid "f8914151-9209-4408-8055-c50a8702543e")
 	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 139.7 45.72 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "176293d3-0e34-4655-a9c5-ce5a89eea41a")
+		(property "Netclass" "RF"
+			(at 138.43 41.402 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 69.85 -20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 187.96 87.63 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "1f667853-ece7-4aba-b2b2-50c88bea2ddc")
+		(property "Netclass" "RF"
+			(at 186.69 83.312 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 118.11 21.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 223.52 83.82 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "566df2e4-37bc-499c-8be0-24e03a3ce9ca")
+		(property "Netclass" "RF"
+			(at 222.25 79.502 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 153.67 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 246.38 83.82 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5b8bf51f-2d9d-4562-971b-ee0d288223d8")
+		(property "Netclass" "RF"
+			(at 245.11 79.502 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 176.53 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 125.73 58.42 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b2dadb9f-4c1e-4d5f-ae3b-cfb49d7592d4")
+		(property "Netclass" "RF"
+			(at 119.888 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 59.69 128.27 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 187.96 80.01 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d0fe107f-ba7f-4fdc-8a1e-692e21e299c6")
+		(property "Netclass" "RF"
+			(at 186.69 75.692 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 118.11 13.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 215.9 83.82 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f68fff34-77c5-4801-940f-c63287d2d424")
+		(property "Netclass" "RF"
+			(at 214.63 79.502 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 146.05 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
+	(netclass_flag ""
+		(length 2.54)
+		(shape round)
+		(at 180.34 87.63 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "fce89d19-128a-4b91-a106-7f05dc09f6a4")
+		(property "Netclass" "RF"
+			(at 179.07 83.312 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Component Class" ""
+			(at 110.49 21.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+	)
 	(symbol
 		(lib_id "Device:C_Small")
 		(at 93.98 105.41 0)


### PR DESCRIPTION
This pull request introduces two new netclasses to support impedance-controlled traces. Trace width calculations are based on a 4-layer PCB stackup with 1 mm thickness.

## Summary of Changes

- Added **USB** netclass for differential USB signals (e.g., USB D+ / D−)
- Added **RF** netclass for any controlled-impedance RF traces (50 Ω)

## PCB Stackup Details (PCBWay 4-layer, 1.0 mm total)

| Layer | Description            | Thickness (mm) after lamination |
|--------|------------------------|----------------------------|
| L1     | Top Copper (1 oz)      | 0.0175                     |
| PP     | Prepreg 7628 RC46%     | 0.1855                     |
| L2     | Inner Copper (1 oz)    | —                          |
| Core   | Core + copper layers   | 0.5                        |
| L3     | Inner Copper (1 oz)    | —                          |
| PP     | Prepreg 7628 RC46%     | 0.1855                     |
| L4     | Bottom Copper (1 oz)   | 0.0175                     |

Dielectric constants:
- Prepreg DK ≈ 4.74
- Core DK ≈ 4.6

---

## Impedance Calculations

### 1. USB Differential Pair (L1 over GND on L2)

**Configuration**: Microstrip differential pair (L1 copper over inner ground L2)  
**Distance to reference plane**: 0.185 mm  
**Dielectric constant (DK)**: 4.74  
**Target impedance**: 90 Ω differential

Approximate results:

- **Trace width**: 0.165 mm  
- **Spacing between USB+ and USB−**: 0.1 mm  
- **Differential impedance**: ~91 Ω

### 2. RF Signal (L1 over GND on L2)

**Configuration**: Microstrip, single-ended  
**Target impedance**: 50 Ω  
**Distance to ground (h)**: 0.185 mm  
**Copper thickness (t)**: ~35 µm  
**Dielectric (εr)**: 4.74

Approximate result:

- **Trace width**: 0.234 mm for 49.97 Ω single-ended impedance
